### PR TITLE
Make title an optional parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,11 @@ module.exports = (options = {}) => {
 	const {title, compareTo, repo, body, assignee, base, template} = options;
 
 	ow(compareTo, ow.string.label('options.compareTo'));
-	ow(title, ow.string.label('options.title'));
 	ow(repo, ow.string.label('options.repo'));
 
+	if (title) {
+		ow(title, ow.string.label('options.title'));
+	}
 	if (body) {
 		ow(body, ow.string.label('options.body'));
 	}

--- a/test.js
+++ b/test.js
@@ -10,27 +10,29 @@ test('throws when required options are invalid', t => {
 		createUrl({compareTo: 23});
 	}, Error);
 	t.throws(() => {
-		createUrl({title: 23});
-	}, Error);
-	t.throws(() => {
 		createUrl({repo: 23});
 	}, Error);
 });
 
-test('should create the repo url', t => {
+test('should create repo url with only required params', t => {
 	const repo = 'abc/foo-repo';
+	const compareTo = 'rocket-branch';
+	t.is(createUrl({
+		repo,
+		compareTo
+	}), `https://github.com/${repo}/compare/master...${compareTo}?quick_pull=1`);
+});
+
+test('should create repo url with all possible params', t => {
+	const repo = 'abc/foo-repo';
+	const base = 'stable';
 	const compareTo = 'rocket-branch';
 	const title = 'awesome-title';
 	const assignee = 'hamxabaig';
 	const body = 'off-to-mars';
-	t.is(createUrl({
-		repo,
-		compareTo,
-		title
-	}), `https://github.com/${repo}/compare/master...${compareTo}?quick_pull=1&title=${title}`);
-	const url = createUrl({repo, compareTo, title, assignee, body});
+	const url = createUrl({repo, base, compareTo, title, assignee, body});
 	const {searchParams} = new URL(url);
-	t.true(url.startsWith(`https://github.com/${repo}/compare/master...${compareTo}`));
+	t.true(url.startsWith(`https://github.com/${repo}/compare/${base}...${compareTo}`));
 	t.is(searchParams.get('body'), body);
 	t.is(searchParams.get('assignee'), assignee);
 	t.is(searchParams.get('title'), title);


### PR DESCRIPTION
### SUMMARY

Allow user to leave `title` undefined, which will then let GitHub provide a default title on the quick pull form. Fixes #1.

### DETAILS

- Make title optional
- Update unit tests
